### PR TITLE
Add Appveyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+# Test against the latest version of this Node.js version
+environment:
+  matrix:
+    - nodejs_version: "8"
+    - nodejs_version: "10"
+
+# Install scripts (runs after repo cloning).
+install:
+  # Get the latest stable version of Node.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm ci
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm run test-win
+
+build:
+  off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
   # Get the latest stable version of Node.js
   - ps: Install-Product node $env:nodejs_version
   # install modules
-  - npm ci
+  - npm install
 
 # Post-install test scripts.
 test_script:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "prepublishOnly": "npm run build",
     "build": "tsc",
     "pretest": "npm run build",
-    "test": "percy exec -- protractor conf.js"
+    "test": "percy exec -- protractor conf.js",
+    "test-win": "npm run pretest && percy exec -- protractor.cmd conf.js"
   },
   "peerDependencies": {},
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "typescript": "^3.1.6"
   },
   "scripts": {
-    "install": "webdriver-manager update",
+    "install": "webdriver-manager update --gecko false",
     "prepublishOnly": "npm run build",
     "build": "tsc",
     "pretest": "npm run build",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "typescript": "^3.1.6"
   },
   "scripts": {
-    "install": "webdriver-manager update --gecko false",
+    "webdriver-update": "webdriver-manager update --gecko false --standalone false",
+    "install": "npm run webdriver-update || npm run webdriver-update",
     "prepublishOnly": "npm run build",
     "build": "tsc",
     "pretest": "npm run build",


### PR DESCRIPTION
Note the ugly "try to install this twice" bit in the npm `install` script. The call to `webdriver-update` fails not infrequently due to network issues (both on my machine, and on CI), and the flakiness seems to be extra-bad on Appveyor.