### PR TITLE
fix: require agentJsFilename directly from @percy/agent

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import fs = require('fs')
-import { agentJsFilename } from '@percy/agent'
+const { agentJsFilename } = require('@percy/agent/dist/utils/sdk-utils')
 import { clientInfo } from './environment'
 
 declare var PercyAgent: any


### PR DESCRIPTION
Require the `agentJsFilename` function directly from @percy/agent to avoid having to include them in the main `@percy/agent` bundle which causes issues as it mixes code that should go into the browser vs code that should run in node.

Related issue: https://github.com/percy/percy-cypress/issues/58