### PR TITLE
fix: Loosen the `@percy/agent` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@percy/agent": "^0.3.1"
+    "@percy/agent": "~0"
   },
   "release": {
     "plugins": [


### PR DESCRIPTION
It allows us to resolve to all 0.x.x versions of agent.