### PR TITLE
fix: CSP fixes by posting DOM from node process

### DIFF
--- a/conf.js
+++ b/conf.js
@@ -8,11 +8,24 @@ exports.config = {
   // Spec files with our tests.
   specs: ['tests/*_spec.js'],
 
+  // Required since we're using `async` / `await`:
+  // "Because async/await uses native promises, it will make the Control Flow
+  // unreliable"
+  // Control Flow is also deprecated
+  // see: https://www.protractortest.org/#/control-flow
+  // see: https://github.com/SeleniumHQ/selenium/issues/2969
+  SELENIUM_PROMISE_MANAGER: false,
+
   // Options for the webdriver instance to use in tests.
   capabilities: {
     browserName: 'chrome',
     chromeOptions: {
-      args: ["--headless"]
+      args: [
+        'headless',
+        'disable-web-security',
+        'ignore-certificate-errors',
+        'allow-running-insecure-content'
+      ]
     }
   }
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2487,7 +2487,7 @@
     },
     "http-errors": {
       "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "requires": {
         "depd": "~1.1.2",

--- a/tests/sdk_spec.js
+++ b/tests/sdk_spec.js
@@ -48,14 +48,10 @@ describe('@percy/protractor SDK', function() {
         'A thing to accomplish',
         protractor.Key.ENTER
       )
-      await percySnapshot('takes multiple snapshots - #1', {
-        widths: [768, 992, 1200],
-      })
+      await percySnapshot('takes multiple snapshots - #1')
 
       await element(by.css('input.toggle')).click()
-      await percySnapshot('takes multiple snapshots - #2', {
-        widths: [768, 992, 1200],
-      })
+      await percySnapshot('takes multiple snapshots - #2')
     })
   })
 

--- a/tests/sdk_spec.js
+++ b/tests/sdk_spec.js
@@ -18,60 +18,63 @@ describe('@percy/protractor SDK', function() {
   })
 
   describe('with local app', function() {
-    beforeEach(function() {
-      browser.get(TEST_URL)
+    beforeEach(async function() {
+      await browser.get(TEST_URL)
     })
 
-    afterEach(function() {
+    afterEach(async function() {
       // Clear local storage between tests so that we always start with a clean slate.
-      browser.executeScript('window.localStorage.clear()')
+      await browser.executeScript('window.localStorage.clear()')
     })
 
-    it('snapshots with provided name', function() {
-      percySnapshot('snapshots with provided name')
+    it('snapshots with provided name', async function() {
+      await percySnapshot('snapshots with provided name')
     })
 
-    it('snapshots with provided name and widths', function() {
-      percySnapshot('snapshots with provided name and widths', {
+    it('snapshots with provided name and widths', async function() {
+      await percySnapshot('snapshots with provided name and widths', {
         widths: [768, 992, 1200],
       })
     })
 
-    it('snapshots with provided name and minHeight', function() {
-      percySnapshot('snapshots with provided name and minHeight', {
+    it('snapshots with provided name and minHeight', async function() {
+      await percySnapshot('snapshots with provided name and minHeight', {
         minHeight: 2000,
       })
     })
 
-    it('takes multiple snapshots in one test', function() {
-      element(by.css('.new-todo')).sendKeys(
+    it('takes multiple snapshots in one test', async function() {
+      await element(by.css('.new-todo')).sendKeys(
         'A thing to accomplish',
         protractor.Key.ENTER
       )
-      percySnapshot('takes multiple snapshots - #1')
+      await percySnapshot('takes multiple snapshots - #1', {
+        widths: [768, 992, 1200],
+      })
 
-      element(by.css('input.toggle')).click()
-      percySnapshot('takes multiple snapshots - #2')
+      await element(by.css('input.toggle')).click()
+      await percySnapshot('takes multiple snapshots - #2', {
+        widths: [768, 992, 1200],
+      })
     })
   })
 
   describe('with live sites', function() {
-    beforeEach(function() {
-      browser.waitForAngularEnabled(false)
-    })
-  
-    afterEach(function() {
-      browser.waitForAngularEnabled(true)
+    beforeEach(async function() {
+      await browser.waitForAngularEnabled(false)
     })
 
-    it('snapshots a website with HTTP', function() {
-      browser.get('http://example.com/')
-      percySnapshot('snapshots a website with HTTP')
+    afterEach(async function() {
+      await browser.waitForAngularEnabled(true)
+    })
+    it('snapshots a website with HTTP', async function() {
+      await browser.get('http://example.com/')
+      await percySnapshot('snapshots a website with HTTP')
     })
 
-    it('snapshots a website with HTTPS, strict CSP, CORS and HSTS setup', function() {
-      browser.get('https://sdk-test.percy.dev')
-      percySnapshot('snapshots a website with HTTPS, strict CSP, CORS and HSTS setup')
+    it('snapshots a website with HTTPS, strict CSP, CORS and HSTS setup', async function() {
+      await browser.get('https://sdk-test.percy.dev')
+      await percySnapshot('snapshots a website with HTTPS, strict CSP, CORS and HSTS setup')
     })
   })
 })


### PR DESCRIPTION
## What is this?

Previously the `PercyAgent` class that was running inside of the browser would POST the DOM back to the agent process. This would cause CSP issues since it's sending a network request to a localhost domain.

This commit will make it so that DOM is `POST`ed from the node process rather than the browser. This is done by capturing the DOM string from the selenium `executeScript` method.

### Control Flow

While doing this I uncovered that we're mixing two different ways to use Protractor / Webdriver. The test suite was written with using WebDriver Control Flow in mind (which manages the promises for you). But our SDK was written with `async` / `await`, which does not work with WebDriver Control Flow. This can cause issues where actions take place out of order:

> Because async/await uses native promises, it will make the Control Flow unreliable.

From: https://www.protractortest.org/#/control-flow

I updated the test suite to disable te Control Flow (like recommended with `async` / `await`). We need to update the docs to reflect this new discovery. Otherwise our users might be seeing weird timing issues with the SDK.