### PR TITLE
feat: Use node v10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,20 +7,20 @@ default_test_steps: &default_test_steps
     - run: yarn test
 
 jobs:
-  test_node_8:
+  test:
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:10-browsers
     environment:
       PERCY_ENABLE: 0
     <<: *default_test_steps
-  test_node_10_with_percy:
+  percy_test:
     # We've opted this node version to be the one that runs and reports Percy's status
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/node:12-browsers
     <<: *default_test_steps
   release:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:12
     steps:
       - checkout
       - run: yarn
@@ -30,9 +30,9 @@ workflows:
   version: 2.1
   test_and_release:
     jobs:
-      - test_node_8
-      - test_node_10_with_percy
+      - test
+      - percy_test
       - release:
           requires:
-            - test_node_8
-            - test_node_10_with_percy
+            - test
+            - percy_test

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "testing"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": "Perceptual Inc.",
   "license": "MIT",


### PR DESCRIPTION
_Potentially breaking release_, so tagged as a feature in case users need to pin to an older version rather than update unmaintained node