### PR TITLE
✨ Work with control flow syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ $ npm install --save-dev @percy/cli @percy/protractor@next
 ```
 ## Usage
 
-This is an example using the `percySnapshot()` function. **Note:** the `percySnapshot()` function
-does not work with Protractor's control flow and only works using
+This is an example using the `percySnapshot()` function using
 [async/await](https://www.protractortest.org/#/async-await).
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -7,35 +7,38 @@ const CLIENT_INFO = `${sdkPkg.name}/${sdkPkg.version}`;
 const ENV_INFO = `${protractorPkg.name}/${protractorPkg.version}`;
 
 // Take a DOM snapshot and post it to the snapshot endpoint
-module.exports = async function percySnapshot(name, options) {
+module.exports = function percySnapshot(name, options) {
   if (!browser) throw new Error('Protractor\'s `browser` was not found.');
   if (!name) throw new Error('The `name` argument is required.');
-  if (!(await utils.isPercyEnabled())) return;
 
-  try {
-    // Inject the DOM serialization script
-    await browser.executeScript(await utils.fetchPercyDOM());
+  return browser.call(async () => {
+    if (!(await utils.isPercyEnabled())) return;
 
-    // Serialize and capture the DOM
-    /* istanbul ignore next: no instrumenting injected code */
-    let { domSnapshot, url } = await browser.executeScript(options => ({
-      /* eslint-disable-next-line no-undef */
-      domSnapshot: PercyDOM.serialize(options),
-      url: document.URL
-    }), options);
+    try {
+      // Inject the DOM serialization script
+      await browser.executeScript(await utils.fetchPercyDOM());
 
-    // Post the DOM to the snapshot endpoint with snapshot options and other info
-    await utils.postSnapshot({
-      ...options,
-      environmentInfo: ENV_INFO,
-      clientInfo: CLIENT_INFO,
-      domSnapshot,
-      name,
-      url
-    });
-  } catch (error) {
-    // Handle errors
-    utils.log('error', `Could not take DOM snapshot "${name}"`);
-    utils.log('error', error);
-  }
+      // Serialize and capture the DOM
+      /* istanbul ignore next: no instrumenting injected code */
+      let { domSnapshot, url } = await browser.executeScript(options => ({
+        /* eslint-disable-next-line no-undef */
+        domSnapshot: PercyDOM.serialize(options),
+        url: document.URL
+      }), options);
+
+      // Post the DOM to the snapshot endpoint with snapshot options and other info
+      await utils.postSnapshot({
+        ...options,
+        environmentInfo: ENV_INFO,
+        clientInfo: CLIENT_INFO,
+        domSnapshot,
+        name,
+        url
+      });
+    } catch (error) {
+      // Handle errors
+      utils.log('error', `Could not take DOM snapshot "${name}"`);
+      utils.log('error', error);
+    }
+  });
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/protractor",
   "description": "Protractor client library for visual testing with Percy",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-protractor",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -26,15 +26,15 @@ describe('percySnapshot', () => {
     browser = og;
   });
 
-  it('throws an error when the browser object is missing', async () => {
+  it('throws an error when the browser object is missing', () => {
     browser = null;
 
-    await expect(percySnapshot()).rejects
+    expect(() => percySnapshot())
       .toThrow('Protractor\'s `browser` was not found.');
   });
 
-  it('throws an error when a name is not provided', async () => {
-    await expect(percySnapshot()).rejects
+  it('throws an error when a name is not provided', () => {
+    expect(() => percySnapshot())
       .toThrow('The `name` argument is required.');
   });
 


### PR DESCRIPTION
## What is this?

Protractor and many WebDriver libraries allow a control flow syntax where asynchronous code can be written as if it were synchronous. While this feature is largely deprecated, current Protractor docs and legacy test suites still use this control flow syntax. Rather than requiring a user to rewrite their entire test suite away from control flow towards async/await in order to use Percy, we can enable control flow usage by utilizing Protractor's [`browser.call`](https://www.protractortest.org/#/api?view=webdriver.WebDriver.prototype.call) method which adds an async function to the control flow context.