### PR TITLE
✨ Allow passing the browser drive to `percySnapshot`

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,21 +7,23 @@ const CLIENT_INFO = `${sdkPkg.name}/${sdkPkg.version}`;
 const ENV_INFO = `${protractorPkg.name}/${protractorPkg.version}`;
 
 // Take a DOM snapshot and post it to the snapshot endpoint
-module.exports = function percySnapshot(name, options) {
-  if (!browser) throw new Error('Protractor\'s `browser` was not found.');
+module.exports = function percySnapshot(b, name, options) {
+  // allow working with or without standalone mode
+  if (!b || typeof b === 'string') [b, name, options] = [browser, b, name];
+  if (!b) throw new Error('Protractor\'s `browser` was not found.');
   if (!name) throw new Error('The `name` argument is required.');
 
-  return browser.call(async () => {
+  return b.call(async () => {
     if (!(await utils.isPercyEnabled())) return;
     let log = utils.logger('protractor');
 
     try {
       // Inject the DOM serialization script
-      await browser.executeScript(await utils.fetchPercyDOM());
+      await b.executeScript(await utils.fetchPercyDOM());
 
       // Serialize and capture the DOM
       /* istanbul ignore next: no instrumenting injected code */
-      let { domSnapshot, url } = await browser.executeScript(options => ({
+      let { domSnapshot, url } = await b.executeScript(options => ({
         /* eslint-disable-next-line no-undef */
         domSnapshot: PercyDOM.serialize(options),
         url: document.URL

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,11 @@
+import { ProtractorBrowser } from 'protractor';
 import { SnapshotOptions } from '@percy/core';
+
+export default function percySnapshot(
+  browser: ProtractorBrowser,
+  name: string,
+  options?: SnapshotOptions
+): Promise<void>;
 
 export default function percySnapshot(
   name: string,

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,9 +1,16 @@
-import { expectType, expectError } from 'tsd';
 import percySnapshot from '.';
+import { expectType, expectError } from 'tsd';
+import { ProtractorBrowser } from 'protractor';
+
+declare const browser: ProtractorBrowser;
 
 expectError(percySnapshot());
+expectError(percySnapshot(browser));
 
-expectType<void>(await percySnapshot('Snapshot name'));
-expectType<void>(await percySnapshot('Snapshot name', { widths: [1000] }));
+expectType<Promise<void>>(percySnapshot('Snapshot name'));
+expectType<Promise<void>>(percySnapshot(browser, 'Snapshot name'));
+expectType<Promise<void>>(percySnapshot('Snapshot name', { widths: [1000] }));
+expectType<Promise<void>>(percySnapshot(browser, 'Snapshot name', { widths: [1000] }));
 
 expectError(percySnapshot('Snapshot name', { foo: 'bar' }));
+expectError(percySnapshot(browser, 'Snapshot name', { foo: 'bar' }));


### PR DESCRIPTION
## What is this?

This will allow users to use this SDK when in standalone mode, too (like our WebdriverIO). https://www.protractortest.org/#/server-setup#standalone-selenium-server