### PR TITLE
✅ Use Percy CLI testing mode for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "install": "webdriver-manager update --no-chrome --no-standalone",
     "lint": "eslint --ignore-path .gitignore .",
-    "test": "protractor protractor.conf.js",
+    "test": "percy exec --testing -- protractor protractor.conf.js",
     "test:coverage": "nyc yarn test",
     "test:types": "tsd"
   },
@@ -33,7 +33,7 @@
     "protractor": "~7"
   },
   "devDependencies": {
-    "@percy/core": "^1.0.0",
+    "@percy/cli": "^1.9.1",
     "eslint": "^7.11.0",
     "eslint-config-standard": "^16.0.1",
     "eslint-plugin-import": "^2.22.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -275,6 +275,69 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@percy/cli-build@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.9.1.tgz#aa2408929bf116a7742c62ebadb3b1e30844fa07"
+  integrity sha512-BeviHvXOnX74Cntw99hRe0HY2eiqFm9BASkfjSB5AoEdtxLKm0xfYM0WcOIec5XtlztRrQKHA49VVOh2pLWK1Q==
+  dependencies:
+    "@percy/cli-command" "1.9.1"
+
+"@percy/cli-command@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.9.1.tgz#bf492875573fc4fc63a9ebf62b33749f298442e6"
+  integrity sha512-4vzOUyorU+0KbqpqXTlSfqRBi+XCPDuPRekNwd0HTsgIQB3KQ8Us5cEhk5x2q8/y0jPHqCb5BK/GJBpS8lwO3Q==
+  dependencies:
+    "@percy/config" "1.9.1"
+    "@percy/core" "1.9.1"
+    "@percy/logger" "1.9.1"
+
+"@percy/cli-config@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.9.1.tgz#e095bf66bec66db0bced9ee926c30a211936321a"
+  integrity sha512-R6bimILhdLswXWnIyU+1+X3h6N0xXuwOBcNT8X3GrcTrBFZJpDJ7CNCxj7f6B5Z5uuEFsvdJKN8rRYfVKLRpwg==
+  dependencies:
+    "@percy/cli-command" "1.9.1"
+
+"@percy/cli-exec@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.9.1.tgz#31ff86b372dc44ce163c0f218c8758413c84d89e"
+  integrity sha512-upWZhJYBvIbQYPhkh0np+RfMYthnhph1FXwaa/Rj4N+RiU/Qb0rFwDf6fz1Je0m1XNPhXu1R/5FnC30W+SsgAg==
+  dependencies:
+    "@percy/cli-command" "1.9.1"
+    cross-spawn "^7.0.3"
+    which "^2.0.2"
+
+"@percy/cli-snapshot@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.9.1.tgz#b494484b08bbc5927bc7b6a9353c4d59b076be0e"
+  integrity sha512-cI4oXI6vrDPEuQaU4xx6wmMozyzhUooNBRh+flu52CQcog6K9DuJnkUuu+Uf/guMX2tacp30UfAq/IMaH3AenA==
+  dependencies:
+    "@percy/cli-command" "1.9.1"
+    yaml "^2.0.0"
+
+"@percy/cli-upload@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.9.1.tgz#f1d97be77cd36574b5a57129be1d3dc1c81bb374"
+  integrity sha512-g72PepLUU0XgZiYSGcSn8nUxTbEW7NYGgh+uo/J3rnIp5OyH5olpIz/+r3+OXezAAwgyLQTSv+/pYY4ClkvQaQ==
+  dependencies:
+    "@percy/cli-command" "1.9.1"
+    fast-glob "^3.2.11"
+    image-size "^1.0.0"
+
+"@percy/cli@^1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.9.1.tgz#0df5b6af5dd848ed1c2a57db4f6e2b547583fe3c"
+  integrity sha512-B62SYu2vHGcR1lkQzP2RHHJRjuEBoWwgeccwBf3mYSzwl4fEB6n1feBRKDx7UNCazRnAzXKrL+g4X7FIesHqnA==
+  dependencies:
+    "@percy/cli-build" "1.9.1"
+    "@percy/cli-command" "1.9.1"
+    "@percy/cli-config" "1.9.1"
+    "@percy/cli-exec" "1.9.1"
+    "@percy/cli-snapshot" "1.9.1"
+    "@percy/cli-upload" "1.9.1"
+    "@percy/client" "1.9.1"
+    "@percy/logger" "1.9.1"
+
 "@percy/client@1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.9.1.tgz#b6d7278436942bf241154cd79a123e23c4cdbcba"
@@ -293,7 +356,7 @@
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/core@^1.0.0":
+"@percy/core@1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.9.1.tgz#ba5a22073cfbf15c20b1964986a8f50b5ee5d024"
   integrity sha512-LLqRoqd2AmbcV4CXQBceeaoZlQGSUN5qyfsNRYQ/7c8AmgTbccy5C1N8bpqaeiyqTpJWduXFGg1TI9awgi1UWQ==
@@ -328,9 +391,9 @@
   integrity sha512-WOtU8eX/fsgz49Hh6N8hSpy95WJV209G9yGFVaZXWIbKJ90FWrONksX/Kz8FxQ0q/7oIW36zXy0ibr2qRy095g==
 
 "@percy/sdk-utils@^1.0.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.8.0.tgz#8db2aefbb211747f8f622db6daf25b781464a308"
-  integrity sha512-ehyYs7L4MDmqjBAfTHA8wDGrsDHiPrJ5SwMA9g9tT06VUey1JJtjSK30VidoouZQm+Sus9r5lW/K73CQZc3lSg==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.9.1.tgz#daa5d2cb9a2dfb306c094c3b6e1ae3891846f5e4"
+  integrity sha512-/9k1XDYj3xl9xI/cQM1uItIcC8HWpm12sYVAZRMKdddCPc3SAQN93sgVZXF3L4uGgaNiTD1+AtkzuUVSccUpPQ==
 
 "@tsd/typescript@~4.7.4":
   version "4.7.4"
@@ -1765,6 +1828,13 @@ ignore@^5.1.1, ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+image-size@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.2.tgz#d778b6d0ab75b2737c1556dd631652eb963bc486"
+  integrity sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==
+  dependencies:
+    queue "6.0.2"
+
 immediate@~3.0.5:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
@@ -2855,6 +2925,13 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+queue@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.2.tgz#b91525283e2315c7553d2efa18d83e76432fed65"
+  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
+  dependencies:
+    inherits "~2.0.3"
+
 quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
@@ -3536,7 +3613,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^2.0.1:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
## What is this?

This PR updates tests to utilize CLI's new testing mode and updated `@percy/sdk-utils` test helpers.