### PR TITLE
chore: release 2.0.3-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/protractor",
   "description": "Protractor client library for visual testing with Percy",
-  "version": "2.0.2-beta.1",
+  "version": "2.0.3-beta.0",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-protractor",


### PR DESCRIPTION
Corrects the beta version: the previous bump (2.0.2-beta.1) was below the already-released stable v2.0.2. Bumps to 2.0.3-beta.0 to ship the merged config-merge change as a proper beta.