### PR TITLE
chore: release 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/protractor",
   "description": "Protractor client library for visual testing with Percy",
-  "version": "2.0.3-beta.0",
+  "version": "2.0.3",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-protractor",


### PR DESCRIPTION
Promotes the PER-8053 config-merge work from `2.0.3-beta.0` to stable `2.0.3`. All non-deprecated SDKs deep-merge .percy.yml config into serializeDOM (per-call priority); verified via the cross-SDK sanity sweep.